### PR TITLE
Lucky env predicates

### DIFF
--- a/spec/lucky_env_spec.cr
+++ b/spec/lucky_env_spec.cr
@@ -35,4 +35,90 @@ describe LuckyEnv do
       ENV["LUCKY_ENV"].should eq "test"
     end
   end
+
+  describe ".development?" do
+    context "when LUCKY_ENV is not set" do
+      it "returns true" do
+        with_lucky_env(nil) do
+          LuckyEnv.development?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to 'development'" do
+      it "returns true" do
+        with_lucky_env("development") do
+          LuckyEnv.development?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to something else" do
+      it "returns false" do
+        with_lucky_env("test") do
+          LuckyEnv.development?.should be_false
+        end
+      end
+    end
+  end
+
+  describe ".test?" do
+    context "when LUCKY_ENV is not set" do
+      it "returns false" do
+        with_lucky_env(nil) do
+          LuckyEnv.test?.should be_false
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to 'test'" do
+      it "returns true" do
+        with_lucky_env("test") do
+          LuckyEnv.test?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to something else" do
+      it "returns false" do
+        with_lucky_env("development") do
+          LuckyEnv.test?.should be_false
+        end
+      end
+    end
+  end
+
+  describe ".production?" do
+    context "when LUCKY_ENV is not set" do
+      it "returns true" do
+        with_lucky_env(nil) do
+          LuckyEnv.production?.should be_false
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to 'production'" do
+      it "returns true" do
+        with_lucky_env("production") do
+          LuckyEnv.production?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_ENV is set to something else" do
+      it "returns false" do
+        with_lucky_env("test") do
+          LuckyEnv.production?.should be_false
+        end
+      end
+    end
+  end
+end
+
+private def with_lucky_env(value, &block)
+  original_value = ENV["LUCKY_ENV"]
+  ENV["LUCKY_ENV"] = value
+  block.call
+ensure
+  ENV["LUCKY_ENV"] = original_value
 end

--- a/spec/lucky_env_spec.cr
+++ b/spec/lucky_env_spec.cr
@@ -39,7 +39,7 @@ describe LuckyEnv do
   describe ".development?" do
     context "when LUCKY_ENV is not set" do
       it "returns true" do
-        with_lucky_env(nil) do
+        with_env("LUCKY_ENV", nil) do
           LuckyEnv.development?.should be_true
         end
       end
@@ -47,7 +47,7 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to 'development'" do
       it "returns true" do
-        with_lucky_env("development") do
+        with_env("LUCKY_ENV", "development") do
           LuckyEnv.development?.should be_true
         end
       end
@@ -55,7 +55,7 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to something else" do
       it "returns false" do
-        with_lucky_env("test") do
+        with_env("LUCKY_ENV", "test") do
           LuckyEnv.development?.should be_false
         end
       end
@@ -65,7 +65,7 @@ describe LuckyEnv do
   describe ".test?" do
     context "when LUCKY_ENV is not set" do
       it "returns false" do
-        with_lucky_env(nil) do
+        with_env("LUCKY_ENV", nil) do
           LuckyEnv.test?.should be_false
         end
       end
@@ -73,7 +73,7 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to 'test'" do
       it "returns true" do
-        with_lucky_env("test") do
+        with_env("LUCKY_ENV", "test") do
           LuckyEnv.test?.should be_true
         end
       end
@@ -81,7 +81,7 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to something else" do
       it "returns false" do
-        with_lucky_env("development") do
+        with_env("LUCKY_ENV", "development") do
           LuckyEnv.test?.should be_false
         end
       end
@@ -91,7 +91,7 @@ describe LuckyEnv do
   describe ".production?" do
     context "when LUCKY_ENV is not set" do
       it "returns true" do
-        with_lucky_env(nil) do
+        with_env("LUCKY_ENV", nil) do
           LuckyEnv.production?.should be_false
         end
       end
@@ -99,7 +99,7 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to 'production'" do
       it "returns true" do
-        with_lucky_env("production") do
+        with_env("LUCKY_ENV", "production") do
           LuckyEnv.production?.should be_true
         end
       end
@@ -107,18 +107,44 @@ describe LuckyEnv do
 
     context "when LUCKY_ENV is set to something else" do
       it "returns false" do
-        with_lucky_env("test") do
+        with_env("LUCKY_ENV", "test") do
           LuckyEnv.production?.should be_false
+        end
+      end
+    end
+  end
+
+  describe ".task?" do
+    context "when LUCKY_TASK is set to 'true'" do
+      it "returns true" do
+        with_env("LUCKY_TASK", "true") do
+          LuckyEnv.task?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_TASK is set to '1'" do
+      it "returns true" do
+        with_env("LUCKY_TASK", "1") do
+          LuckyEnv.task?.should be_true
+        end
+      end
+    end
+
+    context "when LUCKY_TASK is set to something else" do
+      it "returns false" do
+        with_env("LUCKY_TASK", "false") do
+          LuckyEnv.task?.should be_false
         end
       end
     end
   end
 end
 
-private def with_lucky_env(value, &block)
-  original_value = ENV["LUCKY_ENV"]
-  ENV["LUCKY_ENV"] = value
+private def with_env(key, value, &block)
+  original_value = ENV[key]?
+  ENV[key] = value
   block.call
 ensure
-  ENV["LUCKY_ENV"] = original_value
+  ENV[key] = original_value
 end

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -23,4 +23,14 @@ module LuckyEnv
       load(file_path)
     end
   end
+
+  def self.name
+    ENV.fetch("LUCKY_ENV", "development")
+  end
+
+  {% for env in %w[development test production] %}
+    def self.{{ env.id }}?
+      name == {{ env }}
+    end
+  {% end %}
 end

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -33,4 +33,8 @@ module LuckyEnv
       name == {{ env }}
     end
   {% end %}
+
+  def self.task?
+    ENV["LUCKY_TASK"] == "true" || ENV["LUCKY_TASK"] == "1"
+  end
 end

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -5,6 +5,12 @@ require "./lucky_env/*"
 module LuckyEnv
   VERSION = "0.1.2"
 
+  macro add_env(name)
+    def LuckyEnv.{{ name.id }}?
+      environment == {{ name.id.stringify }}
+    end
+  end
+
   # Parses the `file_path`, and loads the results in to `ENV`
   # raises `LuckyEnv::MissingFileError` if the file is missing
   def self.load(file_path : String) : Hash(String, String)
@@ -24,17 +30,15 @@ module LuckyEnv
     end
   end
 
-  def self.name
-    ENV.fetch("LUCKY_ENV", "development")
-  end
-
-  {% for env in %w[development test production] %}
-    def self.{{ env.id }}?
-      name == {{ env }}
-    end
-  {% end %}
-
   def self.task?
     ENV["LUCKY_TASK"] == "true" || ENV["LUCKY_TASK"] == "1"
   end
+
+  def self.environment
+    ENV.fetch("LUCKY_ENV", "development")
+  end
+
+  add_env :development
+  add_env :production
+  add_env :test
 end


### PR DESCRIPTION
This PR addresses parts of #4 by moving the `Lucky::Env` code into [lucky_env](https://github.com/luckyframework/lucky_env) itself.