### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /.shards/
 *.dwarf
 
-
 # Libraries don't need dependency lock
 # Dependencies will be locked in applications that use them
 /shard.lock
+
+# Ignore Desktop Services Store files on macOS
+.DS_Store


### PR DESCRIPTION
macOS creates [Desktop Services Store files](https://en.wikipedia.org/wiki/.DS_Store) that we don't want to include in the Git repository.