### PR TITLE
Release 0.1.4

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky_env
-version: 0.1.3
+version: 0.1.4
 
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>


### PR DESCRIPTION
This release just contains a small fix that stopped apps from compiling if they used `LuckyEnv.task?` but didn't set the ENV var.