### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,11 @@ version: 0.1.4
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: ">= 0.36.1, < 2.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.2
+    version: ~> 1.0.0


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
