### PR TITLE
Raise exception when a duplicate key is found in a file

### DIFF
--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -64,6 +64,12 @@ describe LuckyEnv::Parser do
       data["DB_NAME"].should eq "my_app_development"
       data["LITERAL"].should eq "${NOT_EXISTS_ENV}"
     end
+
+    it "raises on duplicate keys detected" do
+      expect_raises(LuckyEnv::DuplicateKeyDetectedError, /Duplicate key HOST found in \.\/spec\/support\/\.badenv/) do
+        parser.read_file("./spec/support/.badenv")
+      end
+    end
   end
 end
 

--- a/spec/support/.badenv
+++ b/spec/support/.badenv
@@ -1,0 +1,2 @@
+HOST=localhost
+HOST=duplicate_key

--- a/src/lucky_env/errors.cr
+++ b/src/lucky_env/errors.cr
@@ -4,4 +4,7 @@ module LuckyEnv
 
   class MissingFileError < Exception
   end
+
+  class DuplicateKeyDetectedError < Exception
+  end
 end

--- a/src/lucky_env/parser.cr
+++ b/src/lucky_env/parser.cr
@@ -30,7 +30,16 @@ module LuckyEnv
           next if comment?(string)
           key, value = parse_value(string)
 
-          hash[key] = value
+          if hash.has_key?(key)
+            raise LuckyEnv::DuplicateKeyDetectedError.new <<-ERROR
+            Duplicate key #{key} found in #{file_path}.
+            To ignore a key, place a # at the front of the line like this:
+
+            # YOUR_KEY=ignored_value
+            ERROR
+          else
+            hash[key] = value
+          end
         end
 
         keys = hash.keys


### PR DESCRIPTION
Fixes #34

You still have the option to override variables from external ENV sources, but this will at least catch when you have a duplicate defined in your .env file.