### PR TITLE
feat: Implement dynamic reading of the appropriate env file from LUCKY_ENV

### DIFF
--- a/spec/support/.env.development
+++ b/spec/support/.env.development
@@ -1,0 +1,3 @@
+# a comment
+LUCKY_ENV=development
+DEV_PORT=4500

--- a/spec/support/.env.production
+++ b/spec/support/.env.production
@@ -1,0 +1,2 @@
+LUCKY_ENV=production
+SECRET_KEY_BASE=Jcj7ki8pFV=

--- a/spec/support/.env.test
+++ b/spec/support/.env.test
@@ -1,1 +1,2 @@
 LUCKY_ENV=test
+APP_NAME=test_app

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -45,13 +45,13 @@ module LuckyEnv
     test_env = ".env.test"
 
     if LuckyEnv.development? && self.file_loadable?(dev_env)
-      return self.load(dev_env)
+      self.load(dev_env)
     elsif LuckyEnv.production? && self.file_loadable?(prod_env)
-      return self.load(prod_env)
+      self.load(prod_env)
     elsif LuckyEnv.test? && self.file_loadable?(test_env)
-      return self.load(test_env)
+      self.load(test_env)
     else
-      return load(".env") # fallback to ".env"
+      load(".env") # fallback to ".env"
     end
   end
 

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -30,6 +30,36 @@ module LuckyEnv
     end
   end
 
+
+  # Loads the appropriate environment file from the project root directory based on the value of `ENV["LUCKY_ENV"]`.
+  #
+  # This method attempts to read one of the following files depending on the environment:
+  # - `.env.development` for the development environment
+  # - `.env.production` for the production environment
+  # - `.env.testing` for the testing environment
+  #
+  # If no specific file is found for the current environment, it falls back to reading `.env`.
+  # raises LuckyEnv::MissingFileError if no environment file is found.
+  def self.load : Hash(String, String)
+    dev_env = ".env.development"
+    prod_env = ".env.production"
+    test_env = ".env.test"
+
+    if LuckyEnv.development? && self.file_loadable?(dev_env)
+      return self.load(dev_env)
+    elsif LuckyEnv.production? && self.file_loadable?(prod_env)
+      return self.load(prod_env)
+    elsif LuckyEnv.test? && self.file_loadable?(test_env)
+      return self.load(test_env)
+    else
+      return load(".env") # fallback to ".env"
+    end
+  end
+
+  private def self.file_loadable?(file_path : String) : Bool
+    File.exists?(file_path) || File.symlink?(file_path)
+  end
+
   def self.task? : Bool
     ENV["LUCKY_TASK"]? == "true" || ENV["LUCKY_TASK"]? == "1"
   end

--- a/src/lucky_env.cr
+++ b/src/lucky_env.cr
@@ -30,7 +30,6 @@ module LuckyEnv
     end
   end
 
-
   # Loads the appropriate environment file from the project root directory based on the value of `ENV["LUCKY_ENV"]`.
   #
   # This method attempts to read one of the following files depending on the environment:
@@ -38,7 +37,7 @@ module LuckyEnv
   # - `.env.production` for the production environment
   # - `.env.testing` for the testing environment
   #
-  # If no specific file is found for the current environment, it falls back to reading `.env`.
+  # Falls back to reading `.env` if no specific file is found for the current environment.
   # raises LuckyEnv::MissingFileError if no environment file is found.
   def self.load : Hash(String, String)
     dev_env = ".env.development"


### PR DESCRIPTION
Adds dynamic reading of the appropriate env file from the project root directory based on the value of `ENV["LUCKY_ENV"]`.

One of the following files is read depending on the `ENV["LUCKY_ENV"]` value:
  - `.env.development` for  "development"
  - `.env.production` for  "production"
  - `.env.testing` for "testing"

Falls back to reading `.env` if no specific file is found for the current environment.

This is an improvement to https://github.com/luckyframework/lucky_env/pull/17, by automatically loading the appropriate env file simply by calling `LuckyEnv.load`.