### PR TITLE
Fixing CI run and min Crystal require version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
     continue-on-error: false
     steps:
       - name: Download source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
       - name: Install shards
         run: shards install
       - name: Format
@@ -31,11 +33,11 @@ jobs:
         crystal_version: [latest]
         include:
           - os: ubuntu-latest
-            crystal_version: 1.4.0
+            crystal_version: 1.10.0
     runs-on: ${{ matrix.os }}
     continue-on-error: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: crystal-lang/install-crystal@v1
       with:
         crystal: ${{ matrix.crystal_version }}

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.0
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: ">= 1.4.0"
+crystal: ">= 1.10.0"
 
 license: MIT
 

--- a/spec/init_env_spec.cr
+++ b/spec/init_env_spec.cr
@@ -1,3 +1,4 @@
+{% skip_file if compare_versions(Crystal::VERSION, "1.16.0") < 0 %}
 require "./spec_helper"
 
 # Must be called up here, otherwise crystal throws "Error: can't declare def dynamically" error


### PR DESCRIPTION
The rest of the Lucky ecosystem requires at least Crystal 1.10 anyway. The new `init_env` feature also requires Crystal 1.16 or later, so we disable that if we're running below that version to avoid compilation errors.